### PR TITLE
Help command always replies in DMs

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -118,7 +118,8 @@ function parseCommand(msg) {
 
         var cmd = {
             msg: msg,
-            dest: msg.channel
+            dest: msg.channel,
+            author: msg.author
         };
 
         logger.debug("got message from [%s] in channel [%s]: ", 

--- a/plugins/help.js
+++ b/plugins/help.js
@@ -1,6 +1,6 @@
 'use strict';
-var logger = require('winston');
 var co = require('co');
+const expiry = 10000;
 
 var app;
 
@@ -15,15 +15,11 @@ function init(a) {
     return Promise.resolve();
 }
 
-function help(cmd) {
+function help(cmd) {    
     return co(function *init() {
-        var expire = 10000;
-        return cmd.dest.send('*Add a role* \n\`.iam ROLE\`\n\n *Remove a role:*\n \`.iamnot ROLE\`\n (ROLE being job acronym, DRK, SAM, BLM, etc.)\n\n*Add raid leader tag* (to post on #clear_screenshots)\n\`.iam RL\`\n\n*Add guest tag* (to not receive pings anymore)\`.iam guest\`\n\nPlease note that you still need to remove your previous roles manually.\nIf you\'ve accidentally deleted your message in LFG/LFM channel, please note that the moderation team cannot help you bypass the posting limit. Please post on #party_finder until your limit is lifted.');
-
-        // only try and clean up if it's a guild channel
-        if(cmd.dest.type === 'text') {
-            yield Promise.all([cmd.msg.delete(expire), response.delete(expire)]);
-        }
+        if (cmd.dest.type === 'text') {
+            yield Promise.all([cmd.msg.delete(expiry),cmd.author.send('*Add a role* \n\`.iam ROLE\`\n\n *Remove a role:*\n \`.iamnot ROLE\`\n (ROLE being job acronym, DRK, SAM, BLM, etc.)\n\n*Add raid leader tag* (to post on #clear_screenshots)\n\`.iam RL\`\n\n*Add guest tag* (to not receive pings anymore)\`.iam guest\`\n\nPlease note that you still need to remove your previous roles manually.\nIf you\'ve accidentally deleted your message in LFG/LFM channel, please note that the moderation team cannot help you bypass the posting limit. Please post on #party_finder until your limit is lifted.')]);
+        }        
     });
 }
 

--- a/plugins/help.js
+++ b/plugins/help.js
@@ -17,9 +17,13 @@ function init(a) {
 
 function help(cmd) {    
     return co(function *init() {
+        const msgPromise = cmd.author.send('*Add a role* \n\`.iam ROLE\`\n\n *Remove a role:*\n \`.iamnot ROLE\`\n (ROLE being job acronym, DRK, SAM, BLM, etc.)\n\n*Add raid leader tag* (to post on #clear_screenshots)\n\`.iam RL\`\n\n*Add guest tag* (to not receive pings anymore)\`.iam guest\`\n\nPlease note that you still need to remove your previous roles manually.\nIf you\'ve accidentally deleted your message in LFG/LFM channel, please note that the moderation team cannot help you bypass the posting limit. Please post on #party_finder until your limit is lifted.');
+
         if (cmd.dest.type === 'text') {
-            yield Promise.all([cmd.msg.delete(expiry),cmd.author.send('*Add a role* \n\`.iam ROLE\`\n\n *Remove a role:*\n \`.iamnot ROLE\`\n (ROLE being job acronym, DRK, SAM, BLM, etc.)\n\n*Add raid leader tag* (to post on #clear_screenshots)\n\`.iam RL\`\n\n*Add guest tag* (to not receive pings anymore)\`.iam guest\`\n\nPlease note that you still need to remove your previous roles manually.\nIf you\'ve accidentally deleted your message in LFG/LFM channel, please note that the moderation team cannot help you bypass the posting limit. Please post on #party_finder until your limit is lifted.')]);
-        }        
+            yield Promise.all([cmd.msg.delete(expiry), msgPromise]);
+        }  else {
+            return msgPromise;
+        }      
     });
 }
 


### PR DESCRIPTION
1. Added message author to information sent to command in `bot.js`
1. Help command response is sent to the message author
1. `.help` message is automatically deleted from public channels (providing the bot has permission to do this)
1. Removed unused logger requirement from `help.js`
1. Made `expiry` a constant